### PR TITLE
chore: update gitignore and documentation submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,3 +287,4 @@ $RECYCLE.BIN/
 
 # Test environment file
 .env.test
+testing_api/


### PR DESCRIPTION
Add the `testing_api` folder to `.gitignore`, remove an empty documentation submodule, and update the documentation submodule reference.